### PR TITLE
Row switching

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -54,11 +54,11 @@
 
     * Actually, you already implemented a general RREF algorithm to make the #inverse method.
 
-    * [ ] #reduce
+    * [x] #reduce
 
     * [ ] #reduceAug
 
-- [ ] Add support in #inverse and #reduce(Aug) for row switching, rows that have all zeros. See test case 1 for #reduce.
+- [x] Add support in #inverse and #reduce(Aug) for row switching, rows that have all zeros. See test case 1 for #reduce.
 
 - [ ] Add an example to the docs for #reduce?
 

--- a/functions/inverse.js
+++ b/functions/inverse.js
@@ -23,6 +23,20 @@ function inverse(inputMatrix) {
     // Get a leading 1 in the given row.
     if (!almostEquals(matrix[i][i], 1, 2e-12)) {
       let scalar = matrix[i][i];
+      // Swap rows if necessary
+      if (scalar === 0) {
+        let swapped = false;
+        for (let j = i; j < matrix.length; j++) {
+          if (matrix[j][i] !== 0) {
+            let tmpRow = matrix[j].slice(0);
+            matrix[j] = matrix[i].slice(0);
+            matrix[i] = tmpRow;
+            swapped = true;
+            break;
+          }
+        }
+        scalar = swapped ? matrix[i][i] : 1;
+      }
       matrix[i] = matrix[i].map(x => x / scalar);
     }
     // Reduce all other entries in that column to 0. j => row

--- a/functions/inverse.js
+++ b/functions/inverse.js
@@ -31,13 +31,19 @@ function inverse(inputMatrix) {
             let tmpRow = matrix[j].slice(0);
             matrix[j] = matrix[i].slice(0);
             matrix[i] = tmpRow;
+            tmpRow = output[j].slice(0);
+            output[j] = output[i].slice(0);
+            output[i] = tmpRow;
             swapped = true;
             break;
           }
         }
         scalar = swapped ? matrix[i][i] : 1;
+        // `scalar` should never be 1 in #inverse because that would imply a free variable.
+        // (Which would mean that det(matrix) === 0).
       }
       matrix[i] = matrix[i].map(x => x / scalar);
+      output[i] = output[i].map(x => x / scalar);
     }
     // Reduce all other entries in that column to 0. j => row
     // Reduces the rest of the row at the same time.

--- a/functions/reduce.js
+++ b/functions/reduce.js
@@ -13,7 +13,19 @@ function reduce(inputMatrix) {
     // Get a leading 1 in the given row.
     if (!almostEquals(matrix[i][i], 1, 2e-12)) {
       let scalar = matrix[i][i];
-      if (scalar === 0) scalar = 1; // TODO/NOTE: This is a hack.
+      if (scalar === 0) {
+        let swapped = false;
+        for (let j = i; j < matrix.length; j++) {
+          if (matrix[j][i] !== 0) {
+            let tmpRow = matrix[j].slice(0);
+            matrix[j] = matrix[i].slice(0);
+            matrix[i] = tmpRow;
+            swapped = true;
+            break;
+          }
+        }
+        scalar = swapped ? matrix[i][i] : 1;
+      }
       matrix[i] = matrix[i].map(x => x / scalar);
     }
     // Reduce all other entries in that column to 0. j => row

--- a/test/test.js
+++ b/test/test.js
@@ -231,12 +231,13 @@ describe('#reduce', function() {
     assert.equal(equals(matrix.reduce([[1, 2, 3],[-1, -2, -3],[2, 4, 6]]), [[1, 2, 3],[0, 0, 0],[0, 0, 0]]), true);
   });
 
-  it('should support row switching when there is a 0 where we would expect a leading 1', function() {
-    // [[1, 2, 2], [1, 2, 3], [2, 1, 1]] => initial
-    // with row switching => matrix.identity(3)
-    // without switching we get [ [ 1, 2, 0 ], [ 0, 3, 1 ], [ 0, -3, 0 ] ]
-    // which is not technically wrong but it's not fully reduced
+  it('should support row swapping when there is a 0 where we would expect a leading 1', function() {
+    // Without row switching this reduction used to give [ [ 1, 2, 0 ], [ 0, 3, 1 ], [ 0, -3, 0 ] ]
     assert.equal(equals(matrix.reduce([[1, 2, 2], [1, 2, 3], [2, 1, 1]]), matrix.identity(3)), true);
+  });
+
+  it('should not swap any rows if no swap would give a leading nonzero entry', function() {
+    assert.equal(equals(matrix.reduce([[1,1,1],[0,0,2],[0,0,3]]), [[1,1,0],[0,0,0],[0,0,1]]), true);
   });
 
   it('should throw an error if that single argument is not a valid matrix', function() {

--- a/test/test.js
+++ b/test/test.js
@@ -231,6 +231,14 @@ describe('#reduce', function() {
     assert.equal(equals(matrix.reduce([[1, 2, 3],[-1, -2, -3],[2, 4, 6]]), [[1, 2, 3],[0, 0, 0],[0, 0, 0]]), true);
   });
 
+  it('should support row switching when there is a 0 where we would expect a leading 1', function() {
+    // [[1, 2, 2], [1, 2, 3], [2, 1, 1]] => initial
+    // with row switching => matrix.identity(3)
+    // without switching we get [ [ 1, 2, 0 ], [ 0, 3, 1 ], [ 0, -3, 0 ] ]
+    // which is not technically wrong but it's not fully reduced
+    assert.equal(equals(matrix.reduce([[1, 2, 2], [1, 2, 3], [2, 1, 1]]), matrix.identity(3)), true);
+  });
+
   it('should throw an error if that single argument is not a valid matrix', function() {
     expect(() => matrix.reduce([])).to.throw('Invalid matrix');
   });

--- a/test/test.js
+++ b/test/test.js
@@ -189,6 +189,10 @@ describe('#inverse', function() {
     assert.equal(equals( startMatrix, [[1,2,3],[0,1,4],[5,6,0]] ), true);
   });
 
+  it('should support row swapping when there is a 0 where we would expect a leading 1', function() {
+    assert.equal(equals(matrix.inverse([[1,2,2],[1,2,3],[2,1,1]]), [[-1/3,0,2/3],[5/3,-1,-1/3],[-1,1,0]], true), true);
+  });
+
   it('should throw an error if a singular square matrix is passed', function() {
     expect(() => matrix.inverse([[1,2],[1,2]])).to.throw('Matrix is singular (not invertible)');
   });
@@ -229,6 +233,7 @@ describe('#reduce', function() {
     assert.equal(equals(matrix.reduce([[1, 2],[1, 2]]), [[1, 2],[0, 0]]), true);
     assert.equal(equals(matrix.reduce([[1, 1, 3], [1, 2, 1]]), [[1, 0, 5],[0, 1, -2]]), true);
     assert.equal(equals(matrix.reduce([[1, 2, 3],[-1, -2, -3],[2, 4, 6]]), [[1, 2, 3],[0, 0, 0],[0, 0, 0]]), true);
+    assert.equal(equals(matrix.reduce([[1,2],[1,3],[2,2]]), [[1,0],[0,1],[0,0]]), true);
   });
 
   it('should support row swapping when there is a 0 where we would expect a leading 1', function() {


### PR DESCRIPTION
Added support and tests for row swapping in #reduce and #inverse. Fixed an uncaught bug in #inverse while I was there.

This allows matrices to be reduced even if they end up having a 0 on the main diagonal (where we would expect to find a leading 1).